### PR TITLE
Add new DotEnv provider

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,3 +5,6 @@ risky: false
 enabled:
   - phpdoc_order
   - phpdoc_separation
+
+disabled:
+    - not_operator_with_successor_space

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "ext-json": "*"
     },
     "require-dev": {

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -20,7 +20,7 @@ class Arr
      */
     public static function get($array, $key, $default = null)
     {
-        if (! static::accessible($array)) {
+        if (!static::accessible($array)) {
             return $default;
         }
 
@@ -68,7 +68,7 @@ class Arr
             // If the key doesn't exist at this depth, we will just create an empty array
             // to hold the next value, allowing us to create the arrays to hold final
             // values at the correct depth. Then we'll keep digging into the array.
-            if (! isset($array[$key]) || ! is_array($array[$key])) {
+            if (!isset($array[$key]) || !is_array($array[$key])) {
                 $array[$key] = [];
             }
 

--- a/src/Drivers/DotEnv.php
+++ b/src/Drivers/DotEnv.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Sven\FileConfig\Drivers;
+
+class DotEnv implements Driver
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function import(string $contents): array
+    {
+        $parts = explode(PHP_EOL, trim($contents, PHP_EOL));
+
+        $result = [];
+
+        foreach ($parts as $key => $part) {
+            // [
+            //     0 => 'FOO="bar"',
+            //     1 => 'FOO',
+            //     2 => '"',
+            //     3 => 'bar',
+            // ]
+            preg_match('/(\w+)=([\"\']?)(.*)\2/', $part, $matches);
+
+            if ($this->isEmptyLine($part) || $this->isComment($part)) {
+                $result[$key] = $part;
+            } else {
+                $result[$matches[1]] = $matches[3];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function export(array $config): string
+    {
+        $result = '';
+
+        foreach ($config as $key => $value) {
+            if ($this->isEmptyLine($value, $key)) {
+                $result .= PHP_EOL;
+            } elseif ($this->isComment($value)) {
+                $result .= PHP_EOL.$value;
+            } else {
+                $result .= PHP_EOL.$key.'='.$this->quoteIfNecessary($value);
+            }
+        }
+
+        return trim($result, PHP_EOL).PHP_EOL;
+    }
+
+    protected function isEmptyLine(string $value, $key = null): bool
+    {
+        return $value === '' && ! is_string($key);
+    }
+
+    protected function isComment(string $value): bool
+    {
+        return mb_strpos($value, '#') === 0;
+    }
+
+    protected function quoteIfNecessary(string $value): string
+    {
+        // If the string contains anything that is not a
+        // regular "word" like special characters or
+        // spaces, we quote the value and return.
+        if (preg_match('/[\W]/', $value) === 1) {
+            return '"'.$value.'"';
+        }
+
+        return $value;
+    }
+}

--- a/src/Drivers/DotEnv.php
+++ b/src/Drivers/DotEnv.php
@@ -54,7 +54,7 @@ class DotEnv implements Driver
 
     protected function isEmptyLine(string $value, $key = null): bool
     {
-        return $value === '' && ! is_string($key);
+        return $value === '' && !is_string($key);
     }
 
     protected function isComment(string $value): bool

--- a/src/Drivers/Env.php
+++ b/src/Drivers/Env.php
@@ -2,6 +2,9 @@
 
 namespace Sven\FileConfig\Drivers;
 
+/**
+ * @deprecated
+ */
 class Env implements Driver
 {
     const REGEX = '/([a-zA-Z0-9_]+)\=(.+)?/';

--- a/src/Drivers/Env.php
+++ b/src/Drivers/Env.php
@@ -50,7 +50,7 @@ class Env implements Driver
 
     protected function isEmptyLine(string $value, $key = null): bool
     {
-        return $value === '' && ! is_string($key);
+        return $value === '' && !is_string($key);
     }
 
     protected function isComment(string $value): bool

--- a/src/File.php
+++ b/src/File.php
@@ -9,7 +9,7 @@ class File
 
     public function __construct(string $path)
     {
-        if (! is_file($path)) {
+        if (!is_file($path)) {
             throw new \RuntimeException('File not found at "'.$path.'".');
         }
 

--- a/tests/Drivers/DotEnvDriverTest.php
+++ b/tests/Drivers/DotEnvDriverTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Sven\FileConfig\Tests\Drivers;
+
+use Sven\FileConfig\Drivers\Driver;
+use Sven\FileConfig\Drivers\DotEnv;
+
+class DotEnvDriverTest extends DriverTest
+{
+    public function files(): array
+    {
+        return [
+            [
+                'One simple value',
+                "FOO=bar\n",
+                [
+                    'FOO' => 'bar',
+                ],
+            ],
+            [
+                'Multiple values in one file',
+                "FOO=bar\nBAZ=qux\n",
+                [
+                    'FOO' => 'bar',
+                    'BAZ' => 'qux',
+                ],
+            ],
+            [
+                'A single comment',
+                "# A comment\n",
+                [
+                    '# A comment',
+                ],
+            ],
+            [
+                'A comment between two values',
+                "HELLO=world\n# A comment\nGOODBYE=world\n",
+                [
+                    'HELLO' => 'world',
+                    1 => '# A comment',
+                    'GOODBYE' => 'world',
+                ],
+            ],
+            [
+                'Multiple newlines between values',
+                "FOO=bar\nABC=xyz\n\nGHI=jkl\n",
+                [
+                    'FOO' => 'bar',
+                    'ABC' => 'xyz',
+                    2 => '',
+                    'GHI' => 'jkl',
+                ],
+            ],
+            [
+                'Numeric keys',
+                "FOO=bar\n# A comment\nKEY=value\n\n# Second comment\nKEY_2=\"value number two\"\n",
+                [
+                    'FOO' => 'bar',
+                    1 => '# A comment',
+                    'KEY' => 'value',
+                    3 => '',
+                    4 => '# Second comment',
+                    'KEY_2' => 'value number two',
+                ],
+            ],
+            [
+                'Empty values',
+                "FOO=\nHELLO=world\n",
+                [
+                    'FOO' => '',
+                    'HELLO' => 'world',
+                ],
+            ],
+            [
+                'Quote weird characters',
+                "FOO=\"^&!*-)'(>,<cxG+\"\nBLAH=\"blah blah blah\"\n",
+                [
+                    'FOO' => '^&!*-)\'(>,<cxG+',
+                    'BLAH' => 'blah blah blah',
+                ],
+            ],
+        ];
+    }
+
+    protected function driver(): Driver
+    {
+        return new DotEnv();
+    }
+}

--- a/tests/Drivers/DotEnvDriverTest.php
+++ b/tests/Drivers/DotEnvDriverTest.php
@@ -2,8 +2,8 @@
 
 namespace Sven\FileConfig\Tests\Drivers;
 
-use Sven\FileConfig\Drivers\Driver;
 use Sven\FileConfig\Drivers\DotEnv;
+use Sven\FileConfig\Drivers\Driver;
 
 class DotEnvDriverTest extends DriverTest
 {

--- a/tests/Drivers/DotEnvDriverTest.php
+++ b/tests/Drivers/DotEnvDriverTest.php
@@ -12,14 +12,14 @@ class DotEnvDriverTest extends DriverTest
         return [
             [
                 'One simple value',
-                "FOO=bar\n",
+                'FOO=bar'.PHP_EOL,
                 [
                     'FOO' => 'bar',
                 ],
             ],
             [
                 'Multiple values in one file',
-                "FOO=bar\nBAZ=qux\n",
+                'FOO=bar'.PHP_EOL.'BAZ=qux'.PHP_EOL,
                 [
                     'FOO' => 'bar',
                     'BAZ' => 'qux',
@@ -27,14 +27,14 @@ class DotEnvDriverTest extends DriverTest
             ],
             [
                 'A single comment',
-                "# A comment\n",
+                '# A comment'.PHP_EOL,
                 [
                     '# A comment',
                 ],
             ],
             [
                 'A comment between two values',
-                "HELLO=world\n# A comment\nGOODBYE=world\n",
+                'HELLO=world'.PHP_EOL.'# A comment'.PHP_EOL.'GOODBYE=world'.PHP_EOL,
                 [
                     'HELLO' => 'world',
                     1 => '# A comment',
@@ -43,7 +43,7 @@ class DotEnvDriverTest extends DriverTest
             ],
             [
                 'Multiple newlines between values',
-                "FOO=bar\nABC=xyz\n\nGHI=jkl\n",
+                'FOO=bar'.PHP_EOL.'ABC=xyz'.PHP_EOL.PHP_EOL.'GHI=jkl'.PHP_EOL,
                 [
                     'FOO' => 'bar',
                     'ABC' => 'xyz',
@@ -53,7 +53,7 @@ class DotEnvDriverTest extends DriverTest
             ],
             [
                 'Numeric keys',
-                "FOO=bar\n# A comment\nKEY=value\n\n# Second comment\nKEY_2=\"value number two\"\n",
+                'FOO=bar'.PHP_EOL.'# A comment'.PHP_EOL.'KEY=value'.PHP_EOL.PHP_EOL.'# Second comment'.PHP_EOL.'KEY_2="value number two"'.PHP_EOL,
                 [
                     'FOO' => 'bar',
                     1 => '# A comment',
@@ -65,7 +65,7 @@ class DotEnvDriverTest extends DriverTest
             ],
             [
                 'Empty values',
-                "FOO=\nHELLO=world\n",
+                'FOO='.PHP_EOL.'HELLO=world'.PHP_EOL,
                 [
                     'FOO' => '',
                     'HELLO' => 'world',
@@ -73,7 +73,7 @@ class DotEnvDriverTest extends DriverTest
             ],
             [
                 'Quote weird characters',
-                "FOO=\"^&!*-)'(>,<cxG+\"\nBLAH=\"blah blah blah\"\n",
+                'FOO="^&!*-)\'(>,<cxG+"'.PHP_EOL.'BLAH="blah blah blah"'.PHP_EOL,
                 [
                     'FOO' => '^&!*-)\'(>,<cxG+',
                     'BLAH' => 'blah blah blah',

--- a/tests/Drivers/DriverTest.php
+++ b/tests/Drivers/DriverTest.php
@@ -37,6 +37,7 @@ abstract class DriverTest extends TestCase
      * the expected PHP array, in that order.
      *
      * @see \Sven\FileConfig\Tests\Drivers\JsonDriverTest::files
+     *
      * @return array
      */
     abstract public function files(): array;

--- a/tests/Drivers/DriverTest.php
+++ b/tests/Drivers/DriverTest.php
@@ -33,12 +33,11 @@ abstract class DriverTest extends TestCase
 
     /**
      * This data provider should return the title of the test
-     * case the original contents of the file, and then the
-     * expected PHP array, in that order.
-     *
-     * @return array
+     * case, the original contents of the file, and then
+     * the expected PHP array, in that order.
      *
      * @see \Sven\FileConfig\Tests\Drivers\JsonDriverTest::files
+     * @return array
      */
     abstract public function files(): array;
 

--- a/tests/Drivers/EnvDriverTest.php
+++ b/tests/Drivers/EnvDriverTest.php
@@ -5,6 +5,9 @@ namespace Sven\FileConfig\Tests\Drivers;
 use Sven\FileConfig\Drivers\Driver;
 use Sven\FileConfig\Drivers\Env;
 
+/**
+ * @deprecated
+ */
 class EnvDriverTest extends DriverTest
 {
     public function files(): array


### PR DESCRIPTION
This replaces the existing (and now deprecated) `Env` driver, which had some "issues" with quoted values. Take the following `.env` file:

```
HELLO="world"
```

The previous `Env` driver would parse that into `['HELLO' => '"world"']`, notice the extra quotes surrounding the word `'world'`. Seeing as no application would actually read those quotes, this made no sense.

The new `DotEnv` driver properly removes those quotes when parsing the file, with the result of the above file becoming `['HELLO' => 'world']`. When the value needs to be quoted upon writing to the file again, it will do so. To determine what should/shouldn't be surrounded by quotes, it now simply checks if the (new) value matches against `/[\W]/`, meaning anything that is _not_ a "regular word" (like values with special characters like `$`, `^`, `(`, ` `) will be quoted.

---

Once this is released & tagged, I should circle back to https://github.com/svenluijten/flex-env/pull/48, which needs this functionality.