### PR TITLE
Run tests on PHP 8.2 and PHP 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                php: [8.0, 8.1]
+                php: [8.0, 8.1, 8.2, 8.3]
                 os: [ubuntu-latest, windows-latest]
                 dependency-version: [lowest, highest]
         steps:


### PR DESCRIPTION
This PR adds PHP 8.2 and PHP 8.3 to the workflow file to also run the test suite against them.