### PR TITLE
Adds a getOrFail method

### DIFF
--- a/src/Exceptions/KeyNotFoundException.php
+++ b/src/Exceptions/KeyNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Sven\FileConfig\Exceptions;
+
+use Exception;
+
+class KeyNotFoundException extends Exception
+{
+}

--- a/src/Store.php
+++ b/src/Store.php
@@ -3,6 +3,7 @@
 namespace Sven\FileConfig;
 
 use Sven\FileConfig\Drivers\Driver;
+use Sven\FileConfig\Exceptions\KeyNotFoundException;
 
 class Store
 {
@@ -16,6 +17,15 @@ class Store
     public function get($key, $default = null)
     {
         return Arr::get($this->config, $key, $default);
+    }
+
+    public function getOrFail($key)
+    {
+        if (Arr::exists($this->config, $key) === false) {
+            throw new KeyNotFoundException();
+        }
+
+        return $this->get($key);
     }
 
     public function all(): array

--- a/tests/StoreTest.php
+++ b/tests/StoreTest.php
@@ -3,6 +3,7 @@
 namespace Sven\FileConfig\Tests;
 
 use Sven\FileConfig\Drivers\Json;
+use Sven\FileConfig\Exceptions\KeyNotFoundException;
 use Sven\FileConfig\File;
 use Sven\FileConfig\Store;
 
@@ -95,5 +96,18 @@ class StoreTest extends TestCase
         $this->assertArrayHasKey('abc', $values);
         $this->assertEquals('bar', $values['foo']);
         $this->assertEquals('def', $values['abc']);
+    }
+
+    /** @test */
+    public function it_throws_when_getting_a_key_which_doesnt_exist(): void
+    {
+        $this->create('test.json', '{}');
+
+        $file = new File(__DIR__.'/'.self::TEMP_DIRECTORY.'/test.json');
+        $store = new Store($file, new Json());
+
+        $this->expectException(KeyNotFoundException::class);
+
+        $store->getOrFail('foo');
     }
 }


### PR DESCRIPTION
This PR adds a `getOrFail` method which will cause an exception to be raised if the key is not found.

```php
$file = new File('/path/to/file.json');
$config = new Store($file, new Json());

$config->getOrFail('missing-key'); // KeyNotFoundException
```