### PR TITLE
Allow constructing Store via a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,10 @@ object, and an implementation of the `\Sven\FileConfig\Drivers\Driver` interface
 `Json` driver in the examples.
 
 ```php
-use Sven\FileConfig\File;
 use Sven\FileConfig\Store;
 use Sven\FileConfig\Drivers\Json;
 
-$file = new File('/path/to/file.json');
-$config = new Store($file, new Json());
+$config = new Store('/path/to/file.json', new Json());
 ```
 
 You can interact with your newly created `$config` object via the `get`, `set`, and `delete` 

--- a/src/Store.php
+++ b/src/Store.php
@@ -7,10 +7,13 @@ use Sven\FileConfig\Drivers\Driver;
 class Store
 {
     protected array $config;
+    protected File $file;
 
-    public function __construct(protected File $file, protected Driver $driver)
+    public function __construct(string|File $file, protected Driver $driver)
     {
-        $this->config = $driver->import($file->contents());
+        $this->file = is_string($file) ? new File($file) : $file;
+
+        $this->config = $driver->import($this->file->contents());
     }
 
     public function get($key, $default = null)

--- a/tests/StoreTest.php
+++ b/tests/StoreTest.php
@@ -96,4 +96,14 @@ class StoreTest extends TestCase
         $this->assertEquals('bar', $values['foo']);
         $this->assertEquals('def', $values['abc']);
     }
+
+    /** @test */
+    public function it_allows_construction_from_string(): void
+    {
+        $this->create('test.json', '{"foo":"bar"}');
+
+        $store = new Store(__DIR__.'/'.self::TEMP_DIRECTORY.'/test.json', new Json());
+
+        $this->assertEquals('bar', $store->get('foo'));
+    }
 }


### PR DESCRIPTION
This PR allows the `Store` object to be constructed by passing a path string or a `File` instance.

```php
$config = new Store('/path/to/file.json', new Json());
```

The reason this occurred to me was that I found the example in the README a little hard to understand at first glance. This simplifies the default use case.