### PR TITLE
Adds ext-mbstring To Composer Dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 | ^10.0",


### PR DESCRIPTION
This PR adds `mbstring` as a required PHP extension due to use of the `mb_substr` function in `Env->isComment`